### PR TITLE
C++ Config base class for oblique

### DIFF
--- a/conifer/backends/cpp/writer.py
+++ b/conifer/backends/cpp/writer.py
@@ -53,12 +53,12 @@ class CPPModel(ModelBase):
       newline = line
       if '// conifer insert typedef' in line:
         
-        newline =  f"struct BDTConfig {'{'}\n"
+        newline =  "struct BDTConfig : conifer::ConiferConfiguration {\n"
         newline += f"    typedef {cfg.threshold_precision} threshold_t;\n"  
         newline += f"    typedef {cfg.input_precision} input_t;\n"
         newline += f"    typedef {cfg.weight_precision} weight_t;\n"  
         newline += f"    typedef {cfg.score_precision} score_t;\n"
-        newline += f"     static constexpr bool useAddTree = false;\n"  
+        newline += f"    static constexpr bool useAddTree = false;\n"
         newline += f"{'}'};\n"
       elif 'PYBIND11_MODULE' in line:
         newline = line.replace('conifer_bridge', f'conifer_bridge_{self._stamp}')


### PR DESCRIPTION
I was thinking about the configuration class. While I think it's the right way to go, it needs to be made obvious to the user which fields their configuration should define. I think that providing a base class, and forcing that the provided configuration derives from this base class is a good way to achieve that. I believe the user will more easily create a correct configuration this way. 